### PR TITLE
Bumped nuke & added more options for loading image from url (ignoring cache, providing imageIdKey)

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "kean/Nuke" == 9.6.1
+github "kean/Nuke" == 10.3.1

--- a/NukeProxy/NukeProxy.swift
+++ b/NukeProxy/NukeProxy.swift
@@ -39,21 +39,28 @@ public class ImagePipeline : NSObject {
     }
     
     @objc
-    public func loadImage(url: URL, key: String, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
-        let request = ImageRequest(
-            url: url,
-            options: ImageRequestOptions(cacheKey: key)
-        )
-        
+    public func loadImage(url: URL, imageIdKey: String, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
         let options = ImageLoadingOptions(placeholder: placeholder, failureImage: errorImage)
         
-        Nuke.loadImage(with: request, options: options, into: into)
+        Nuke.loadImage(with: ImageRequest(
+            url: url,
+            userInfo: [.imageIdKey: imageIdKey]
+        ), options: options, into: into)
     }
     
     @objc
     public func loadData(url: URL, onCompleted: @escaping (Data?, URLResponse?) -> Void) {
+        loadData(url: url, imageIdKey: nil, reloadIgnoringCachedData: false, onCompleted: onCompleted)
+    }
+    
+    @objc
+    public func loadData(url: URL, imageIdKey: String?, reloadIgnoringCachedData: Bool, onCompleted: @escaping (Data?, URLResponse?) -> Void) {
         _ = Nuke.ImagePipeline.shared.loadData(
-            with: url,
+            with: ImageRequest(
+                url: url,
+                options: reloadIgnoringCachedData ? [.reloadIgnoringCachedData] : [],
+                userInfo: [.imageIdKey: imageIdKey]
+            ),
             completion: { result in
                 switch result {
                 case let .success(response):

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Open the NukeProxy.xcodeproj in Xcode and add more code to `NukeProxy.swift`.
 
 Make sure to annotate correctly with `@objc`. Refer to the other code and [Xamarin.iOS Swift Bindings][bindings]. When done adding more code, ensure project builds:
 
-1. Run `sh build-fat.sh` from commandline
+1. Run `sh build-fat.sh` from commandline (make sure you have [the latest Sharpie][sharpie] installed)
 2. Copy the new definitions from the `sharpie_output` folder into the `Xamarin.Nuke` C# project
 3. Adjust the definitions and ensure the project builds
 4. Create a PR to this repository
@@ -37,3 +37,4 @@ Make sure to annotate correctly with `@objc`. Refer to the other code and [Xamar
 [nuke]:https://github.com/kean/Nuke
 [xformsnuke]:https://github.com/roubachof/Xamarin.Forms.Nuke
 [bindings]:https://docs.microsoft.com/en-us/xamarin/ios/platform/binding-swift/walkthrough
+[sharpie]:https://docs.microsoft.com/en-us/xamarin/cross-platform/macios/binding/objective-sharpie/releases?context=xamarin/ios

--- a/Xamarin.Nuke.nuspec
+++ b/Xamarin.Nuke.nuspec
@@ -11,8 +11,7 @@
     <owners>roubachof,cheesebaron</owners>
     <license type="file">LICENSE</license>
     <projectUrl>https://github.com/roubachof/Xamarin.Nuke</projectUrl>
-    <repository type="git" url="https://github.com/roubachof/NukeProxy.git"/>
-
+    <repositoryUrl>https://github.com/roubachof/Xamarin.Nuke</repositoryUrl>
     <icon>images\nuke_small.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 

--- a/Xamarin.Nuke.nuspec
+++ b/Xamarin.Nuke.nuspec
@@ -11,7 +11,8 @@
     <owners>roubachof,cheesebaron</owners>
     <license type="file">LICENSE</license>
     <projectUrl>https://github.com/roubachof/Xamarin.Nuke</projectUrl>
-    <repositoryUrl>https://github.com/roubachof/Xamarin.Nuke</repositoryUrl>
+    <repository type="git" url="https://github.com/roubachof/NukeProxy.git"/>
+
     <icon>images\nuke_small.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 

--- a/Xamarin.Nuke/Xamarin.Nuke/ApiDefinition.cs
+++ b/Xamarin.Nuke/Xamarin.Nuke/ApiDefinition.cs
@@ -48,15 +48,22 @@ namespace Xamarin.Nuke
 
 		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
 		[Export("loadImageWithUrl:placeholder:errorImage:into:")]
-		void LoadImageWithUrl(NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
+		void LoadImageWithUrl(NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage,
+			UIImageView into);
 
-		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url key:(NSString * _Nonnull)key placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
-		[Export("loadImageWithUrl:key:placeholder:errorImage:into:")]
-		void LoadImageWithUrl(NSUrl url, string key, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
+		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
+		[Export("loadImageWithUrl:imageIdKey:placeholder:errorImage:into:")]
+		void LoadImageWithUrl(NSUrl url, string imageIdKey, [NullAllowed] UIImage placeholder,
+			[NullAllowed] UIImage errorImage, UIImageView into);
 
 		// -(void)loadDataWithUrl:(NSURL * _Nonnull)url onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSURLResponse * _Nullable))onCompleted;
 		[Export("loadDataWithUrl:onCompleted:")]
-		void LoadDataWithUrl (NSUrl url, Action<NSData, NSUrlResponse> onCompleted);
+		void LoadDataWithUrl(NSUrl url, Action<NSData, NSUrlResponse> onCompleted);
+
+		// -(void)loadDataWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nullable)imageIdKey reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSURLResponse * _Nullable))onCompleted;
+		[Export("loadDataWithUrl:imageIdKey:reloadIgnoringCachedData:onCompleted:")]
+		void LoadDataWithUrl(NSUrl url, [NullAllowed] string imageIdKey, bool reloadIgnoringCachedData,
+			Action<NSData, NSUrlResponse> onCompleted);
 	}
 
 	// @interface Prefetcher : NSObject

--- a/build-fat.sh
+++ b/build-fat.sh
@@ -2,7 +2,7 @@
 # https://docs.microsoft.com/en-us/xamarin/ios/platform/binding-swift/walkthrough
 
 echo "Define parameters"
-IOS_SDK_VERSION="14.4" # xcodebuild -showsdks
+IOS_SDK_VERSION="14.5" # xcodebuild -showsdks
 SWIFT_PROJECT_NAME="NukeProxy"
 SWIFT_PROJECT_PATH="$SWIFT_PROJECT_NAME.xcodeproj"
 SWIFT_BUILD_PATH="Output/build"
@@ -37,7 +37,7 @@ mkdir -p "$SWIFT_OUTPUT_PATH"
 cp -Rf "$SWIFT_BUILD_PATH/Release-fat/$SWIFT_PROJECT_NAME.framework" "$SWIFT_OUTPUT_PATH"
 
 echo "Generating binding api definition and structs"
-sharpie bind --sdk=iphoneos$IOS_SDK_VERSION --output="$SWIFT_OUTPUT_PATH/XamarinApiDef" --namespace="Binding" --scope="$SWIFT_OUTPUT_PATH/$SWIFT_PROJECT_NAME.framework/Headers/" "$SWIFT_OUTPUT_PATH/$SWIFT_PROJECT_NAME.framework/Headers/$SWIFT_PROJECT_NAME-Swift.h"
+sharpie bind --sdk=iphoneos$IOS_SDK_VERSION --output="$SWIFT_OUTPUT_PATH/XamarinApiDef" --namespace="Xamarin.Nuke" --scope="$SWIFT_OUTPUT_PATH/$SWIFT_PROJECT_NAME.framework/Headers/" "$SWIFT_OUTPUT_PATH/$SWIFT_PROJECT_NAME.framework/Headers/$SWIFT_PROJECT_NAME-Swift.h"
 
 echo "Replace existing metadata with the udpated"
 cp -Rf "$SWIFT_OUTPUT_PATH/XamarinApiDef/." "$XAMARIN_BINDING_PATH/"

--- a/build-fat.sh
+++ b/build-fat.sh
@@ -2,7 +2,7 @@
 # https://docs.microsoft.com/en-us/xamarin/ios/platform/binding-swift/walkthrough
 
 echo "Define parameters"
-IOS_SDK_VERSION="14.5" # xcodebuild -showsdks
+IOS_SDK_VERSION="14.4" # xcodebuild -showsdks
 SWIFT_PROJECT_NAME="NukeProxy"
 SWIFT_PROJECT_PATH="$SWIFT_PROJECT_NAME.xcodeproj"
 SWIFT_BUILD_PATH="Output/build"


### PR DESCRIPTION
Hey, thanks for the work on this project, here are some changes which I'd love to get merged ☺️

- Bumped Nuke from 9.6.1 to 10.3.1 ([changelog](https://github.com/kean/Nuke/blob/master/CHANGELOG.md)), it required using [_imageIdKey_](https://kean-org.github.io/docs/nuke/reference/10.0.0/ImageRequest_UserInfoKey/#imagerequest.userinfokey.imageidkey) instead of _cacheKey_, which modified parameter name (breaking change)
- Added an "overload" for LoadDataWithUrl with _[imageIdKey](https://kean-org.github.io/docs/nuke/reference/10.0.0/ImageRequest_UserInfoKey/#imagerequest.userinfokey.imageidkey)_ and an option to [ignore cached images](https://kean-org.github.io/docs/nuke/reference/10.2.0/ImageRequest_Options/#imagerequest.options.reloadignoringcacheddata) (useful when you want to force refresh the image from source)
- Changed namespace of sharpie generated files to Xamarin.Nuke
- Added a link to the latest sharpie in readme