### PR TITLE
Remove embedded Nuke.framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - name: Checkout

--- a/NukeProxy.xcodeproj/project.pbxproj
+++ b/NukeProxy.xcodeproj/project.pbxproj
@@ -8,24 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		7D013CDE265D5A2100454172 /* Nuke.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D013CDD265D5A2100454172 /* Nuke.xcframework */; };
-		7D013CDF265D5A2100454172 /* Nuke.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D013CDD265D5A2100454172 /* Nuke.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B08309D5241256530090FB75 /* NukeProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = B08309D3241256530090FB75 /* NukeProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B08309E7241259650090FB75 /* NukeProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08309E6241259650090FB75 /* NukeProxy.swift */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		7D013CE0265D5A2100454172 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				7D013CDF265D5A2100454172 /* Nuke.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		7D013CDD265D5A2100454172 /* Nuke.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nuke.xcframework; path = Carthage/Build/Nuke.xcframework; sourceTree = "<group>"; };
@@ -104,7 +89,6 @@
 				B08309CC241256530090FB75 /* Sources */,
 				B08309CD241256530090FB75 /* Frameworks */,
 				B08309CE241256530090FB75 /* Resources */,
-				7D013CE0265D5A2100454172 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/build-fat.sh
+++ b/build-fat.sh
@@ -2,7 +2,7 @@
 # https://docs.microsoft.com/en-us/xamarin/ios/platform/binding-swift/walkthrough
 
 echo "Define parameters"
-IOS_SDK_VERSION="14.4" # xcodebuild -showsdks
+IOS_SDK_VERSION="14.5" # xcodebuild -showsdks
 SWIFT_PROJECT_NAME="NukeProxy"
 SWIFT_PROJECT_PATH="$SWIFT_PROJECT_NAME.xcodeproj"
 SWIFT_BUILD_PATH="Output/build"


### PR DESCRIPTION
Found out I had accidentally marked Nuke.framework to be embedded & signed in the xcode project

![Screenshot 2021-08-18 at 10 25 52](https://user-images.githubusercontent.com/249719/129869731-31e83399-2a5d-4cce-9f74-7084fcba510f.png)

This isn't good as we add Nuke.framework in the binding library as well. So the structure would be like:

- NukeProxy
  - Nuke
- Nuke

But what we want is

- NukeProxy
- Nuke

So I've marked the Nuke.framework reference in xcode to not be embedded to hopefully fix this:

![Screenshot 2021-08-18 at 10 26 33](https://user-images.githubusercontent.com/249719/129870070-69073d90-08b8-4097-8bce-13f332e845e4.png)


Fixes #3 