### PR TITLE
Option to use DataCache, exposed more cache helper methods

### DIFF
--- a/NukeProxy/NukeProxy.swift
+++ b/NukeProxy/NukeProxy.swift
@@ -10,11 +10,41 @@ import Foundation
 import UIKit
 import Nuke
 
+
 @objc(ImagePipeline)
 public class ImagePipeline : NSObject {
     
     @objc
     public static let shared = ImagePipeline()
+    
+    @objc
+    public static func setupWithDataCache(){
+        Nuke.ImagePipeline.shared = Nuke.ImagePipeline(configuration: .withDataCache)
+    }
+    
+    @objc
+    public func isCached(for url: URL) -> Bool {
+        return Nuke.ImagePipeline.shared.cache.containsCachedImage(for: ImageRequest(url: url))
+    }
+    
+    @objc
+    public func getCachedImage(for url: URL) -> UIImage? {
+        guard let cached = Nuke.ImagePipeline.shared.cache.cachedImage(for: ImageRequest(url: url)) else {
+            return nil
+        }
+        
+        return cached.image
+    }
+    
+    @objc
+    public func removeImageFromCache(for url: URL) {
+        Nuke.ImagePipeline.shared.cache.removeCachedData(for: ImageRequest(url: url))
+    }
+    
+    @objc
+    public func removeAllCaches() {
+        Nuke.ImagePipeline.shared.cache.removeAll()
+    }
     
     @objc
     public func loadImage(url: URL, onCompleted: @escaping (UIImage?, String) -> Void) {
@@ -31,6 +61,7 @@ public class ImagePipeline : NSObject {
             }
         )
     }
+    
     
     @objc
     public func loadImage(url: URL, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
@@ -100,7 +131,7 @@ public final class DataLoader: NSObject {
 @objc(Prefetcher)
 public final class Prefetcher: NSObject {
  
-    let prefetcher = ImagePrefetcher()
+    let prefetcher: ImagePrefetcher = ImagePrefetcher()
     
     @objc
     public func startPrefetching(with: [URL]) {

--- a/NukeProxy/NukeProxy.swift
+++ b/NukeProxy/NukeProxy.swift
@@ -131,7 +131,7 @@ public final class DataLoader: NSObject {
 @objc(Prefetcher)
 public final class Prefetcher: NSObject {
  
-    let prefetcher: ImagePrefetcher = ImagePrefetcher()
+    let prefetcher = ImagePrefetcher()
     
     @objc
     public func startPrefetching(with: [URL]) {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Open the NukeProxy.xcodeproj in Xcode and add more code to `NukeProxy.swift`.
 
 Make sure to annotate correctly with `@objc`. Refer to the other code and [Xamarin.iOS Swift Bindings][bindings]. When done adding more code, ensure project builds:
 
-1. Run `sh build-fat.sh` from commandline (make sure you have [the latest Sharpie][sharpie] installed)
+1. Run `sh build.sh` from commandline (make sure you have [the latest Sharpie][sharpie] installed)
 2. Copy the new definitions from the `sharpie_output` folder into the `Xamarin.Nuke` C# project
 3. Adjust the definitions and ensure the project builds
 4. Create a PR to this repository

--- a/src/ImageCaching.Nuke/ApiDefinition.cs
+++ b/src/ImageCaching.Nuke/ApiDefinition.cs
@@ -42,6 +42,28 @@ namespace Xamarin.Nuke
 		[Export ("shared", ArgumentSemantic.Strong)]
 		ImagePipeline Shared { get; }
 
+		// +(void)setupWithDataCache;
+		[Static]
+		[Export ("setupWithDataCache")]
+		void SetupWithDataCache ();
+
+		// -(BOOL)isCachedFor:(NSURL * _Nonnull)url __attribute__((warn_unused_result("")));
+		[Export ("isCachedFor:")]
+		bool IsCachedFor (NSUrl url);
+
+		// -(UIImage * _Nullable)getCachedImageFor:(NSURL * _Nonnull)url __attribute__((warn_unused_result("")));
+		[Export ("getCachedImageFor:")]
+		[return: NullAllowed]
+		UIImage GetCachedImageFor (NSUrl url);
+
+		// -(void)removeImageFromCacheFor:(NSURL * _Nonnull)url;
+		[Export ("removeImageFromCacheFor:")]
+		void RemoveImageFromCacheFor (NSUrl url);
+
+		// -(void)removeAllCaches;
+		[Export ("removeAllCaches")]
+		void RemoveAllCaches ();
+
 		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url onCompleted:(void (^ _Nonnull)(UIImage * _Nullable, NSString * _Nonnull))onCompleted;
 		[Export ("loadImageWithUrl:onCompleted:")]
 		void LoadImageWithUrl (NSUrl url, Action<UIImage, NSString> onCompleted);

--- a/src/Sample/ViewController.cs
+++ b/src/Sample/ViewController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Foundation;
 using SkiaSharp;
 using SkiaSharp.Views.iOS;
@@ -10,9 +11,30 @@ namespace Sample
     public partial class ViewController : UIViewController
     {
         private SKBitmap _bitmap;
+        private readonly NSUrl _bottomImageUrl = new NSUrl("https://placekitten.com/g/1000/1000"); 
+        private readonly NSUrl _topImageUrl = new NSUrl("https://placekitten.com/g/300/300");
+        private readonly Prefetcher _imagePrefetcher = new Prefetcher();
 
+        private UIButton _streamButton, _placeholderButton, _clearButton, _prefetchButton, _dumpCacheStateButton;
+        private UIImageView _imageView;
+        private SKCanvasView _skiaCanvasView;
+        private UIStackView _bottomStackView;
+        private UILabel _cacheStatusLabel;
+        
         public ViewController(IntPtr handle) : base(handle)
         {
+        }
+
+        private void LogCacheState()
+        {
+            var msg =
+                $"👋 Images in cache: Top->{ImagePipeline.Shared.IsCachedFor(_topImageUrl)}, Bottom->{ImagePipeline.Shared.IsCachedFor(_bottomImageUrl)}";
+            System.Console.WriteLine(msg);
+
+            if (_cacheStatusLabel != null)
+            {
+                _cacheStatusLabel.Text = msg;
+            }
         }
 
         public override void ViewDidLoad()
@@ -20,80 +42,135 @@ namespace Sample
             base.ViewDidLoad();
             // Perform any additional setup after loading the view, typically from a nib.
 
-            var image = new UIImageView
+            // Remove to use default, in-memory cache
+            ImagePipeline.SetupWithDataCache();
+
+            _bottomStackView = new UIStackView
             {
+                Axis = UILayoutConstraintAxis.Vertical,
+                Spacing = 8f,
+                Alignment = UIStackViewAlignment.Fill,
+                Distribution = UIStackViewDistribution.FillEqually,
                 TranslatesAutoresizingMaskIntoConstraints = false
             };
             
-            Add(image);
+            Add(_bottomStackView);
+            
+            _imageView = new UIImageView
+            {
+                TranslatesAutoresizingMaskIntoConstraints = false,
+                BackgroundColor = UIColor.Gray
+            };
+            
+            Add(_imageView);
 
-            ImagePipeline.Shared.LoadImageWithUrl(
-                new NSUrl("https://placekitten.com/g/300/300"),
-                (img, url) => image.Image = img);
-
-            UIButton button = AddButton("Placeholder");
-
-            button.TouchUpInside += (s, e) =>
+            _placeholderButton = AddButton("Load with placeholder");
+            Add(_placeholderButton);
+            
+            _placeholderButton.TouchUpInside += (s, e) =>
             {
                 ImageCache.Shared.RemoveAll();
-
+                
                 ImagePipeline.Shared.LoadImageWithUrl(
-                    new NSUrl("https://placekitten.com/g/1000/1000"),
+                    _topImageUrl,
                     UIImage.FromBundle("Placeholder"),
                     null,
-                    image);
+                    _imageView);
             };
 
-            var skiaView = new SKCanvasView
+            _skiaCanvasView = new SKCanvasView
             {
                 TranslatesAutoresizingMaskIntoConstraints = false
             };
-            skiaView.PaintSurface += OnPaintSurface;
-            Add(skiaView);
+            _skiaCanvasView.PaintSurface += OnPaintSurface;
+            Add(_skiaCanvasView);
 
-            UIButton button2 = AddButton("Streamed image");
-
-            button2.TouchUpInside += (s, e) =>
+            _streamButton = AddButton("Load streamed image");
+            Add(_streamButton);
+            _streamButton.TouchUpInside += (s, e) =>
             {
-                ImagePipeline.Shared.LoadDataWithUrl(new NSUrl("https://placekitten.com/g/1000/1000"), (data, response) =>
+                ImagePipeline.Shared.LoadDataWithUrl(_bottomImageUrl, (data, response) =>
                 {
                     using var dataStream = data.AsStream();
                     _bitmap = SKBitmap.Decode(dataStream);
 
-                    skiaView.LayoutSubviews();
+                    _skiaCanvasView.LayoutSubviews();
                 });
             };
 
-            AddConstraints(image, button, button2, skiaView);
+            _clearButton = AddButton("Clear caches & images");
+            _clearButton.TouchUpInside += (sender, args) =>
+            {
+                ClearDiskCache();
+                _bitmap = null; 
+                _skiaCanvasView.LayoutSubviews();
+                 _imageView.Image = null;
+            };
+            
+            _prefetchButton = AddButton("Prefetch above images");
+            _prefetchButton.TouchUpInside += (sender, args) =>
+            {
+                StartPrefetchingImages();
+            };
+
+            _dumpCacheStateButton = AddButton("Show cache status");
+            _dumpCacheStateButton.TouchUpInside += (sender, args) =>
+            {
+                LogCacheState();
+            };
+            
+            _cacheStatusLabel = new UILabel(){ Lines = 0, TranslatesAutoresizingMaskIntoConstraints = false};
+            
+            _bottomStackView.AddArrangedSubview(_clearButton);
+            _bottomStackView.AddArrangedSubview(_prefetchButton);
+            _bottomStackView.AddArrangedSubview(_dumpCacheStateButton);
+            
+            Add(_cacheStatusLabel);
+
+            AddConstraints();
         }
 
         private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
         {
+            e.Surface.Canvas.Clear(SKColors.Gray);
+            
             if (_bitmap == null)
                 return;
-
+            
             e.Surface.Canvas.DrawBitmap(_bitmap, SKPoint.Empty);
         }
 
-        private void AddConstraints(UIImageView image, UIButton button, UIButton button2, SKCanvasView skiaView)
+        private void AddConstraints()
         {
-            image.WidthAnchor.ConstraintEqualTo(View.WidthAnchor).Active = true;
-            image.HeightAnchor.ConstraintEqualTo(View.WidthAnchor).Active = true;
-            image.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
-            image.TopAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.TopAnchor).Active = true;
+            _imageView.TopAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.TopAnchor, 16f).Active = true;
+            _imageView.WidthAnchor.ConstraintEqualTo(View.WidthAnchor, 0.5f).Active = true;
+            _imageView.HeightAnchor.ConstraintEqualTo(_imageView.WidthAnchor).Active = true;
+            _imageView.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
 
-            button.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor, 16).Active = true;
-            button.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor, -16).Active = true;
-            button.BottomAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.BottomAnchor, -20).Active = true;
+            _placeholderButton.TopAnchor.ConstraintEqualTo(_imageView.BottomAnchor, 16f).Active = true;
+            _placeholderButton.WidthAnchor.ConstraintEqualTo(View.WidthAnchor, 0.95f).Active = true;
+            _placeholderButton.HeightAnchor.ConstraintEqualTo(30f).Active = true;
+            _placeholderButton.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
 
-            button2.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor, 16).Active = true;
-            button2.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor, -16).Active = true;
-            button2.BottomAnchor.ConstraintEqualTo(button.TopAnchor, -20).Active = true;
+            _skiaCanvasView.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
+            _skiaCanvasView.TopAnchor.ConstraintEqualTo(_placeholderButton.BottomAnchor, 16f).Active = true;
+            _skiaCanvasView.WidthAnchor.ConstraintEqualTo(View.WidthAnchor, 0.5f).Active = true;
+            _skiaCanvasView.HeightAnchor.ConstraintEqualTo(_skiaCanvasView.WidthAnchor).Active = true;
 
-            skiaView.TopAnchor.ConstraintEqualTo(image.BottomAnchor, 10).Active = true;
-            skiaView.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor, 16).Active = true;
-            skiaView.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor, -16).Active = true;
-            skiaView.BottomAnchor.ConstraintEqualTo(button2.TopAnchor, -16).Active = true;
+            _streamButton.TopAnchor.ConstraintEqualTo(_skiaCanvasView.BottomAnchor, 16f).Active = true;
+            _streamButton.WidthAnchor.ConstraintEqualTo(View.WidthAnchor, 0.95f).Active = true;
+            _streamButton.HeightAnchor.ConstraintEqualTo(30f).Active = true;
+            _streamButton.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
+
+            _bottomStackView.TopAnchor.ConstraintEqualTo(_streamButton.BottomAnchor, 16f).Active = true;
+            _bottomStackView.HeightAnchor.ConstraintEqualTo(106).Active = true;
+            _bottomStackView.WidthAnchor.ConstraintEqualTo(View.WidthAnchor, 0.95f).Active = true;
+            _bottomStackView.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
+
+            _cacheStatusLabel.TopAnchor.ConstraintEqualTo(_bottomStackView.BottomAnchor).Active = true;
+            _cacheStatusLabel.WidthAnchor.ConstraintEqualTo(View.WidthAnchor, 0.95f).Active = true;
+            _cacheStatusLabel.CenterXAnchor.ConstraintEqualTo(View.CenterXAnchor).Active = true;
+            
         }
 
         private UIButton AddButton(string title)
@@ -106,7 +183,6 @@ namespace Sample
             button.SetTitleColor(UIColor.Black, UIControlState.Normal);
             button.SetTitle(title, UIControlState.Normal);
 
-            Add(button);
             return button;
         }
 
@@ -115,5 +191,22 @@ namespace Sample
             base.DidReceiveMemoryWarning();
             // Release any cached data, images, etc that aren't in use.
         }
+
+        private void StartPrefetchingImages()
+        {
+            _imagePrefetcher.StartPrefetchingWith(new[] {_bottomImageUrl, _topImageUrl});
+        }
+
+        private void ClearDiskCache()
+        {
+            ImagePipeline.Shared.RemoveAllCaches();
+        }
+
+        private void RemoveFromCache(NSUrl url)
+        {
+            ImagePipeline.Shared.RemoveImageFromCacheFor(url);
+        }
+
+        private UIImage? GetFromCache(NSUrl url) => ImagePipeline.Shared.GetCachedImageFor(url);
     }
 }


### PR DESCRIPTION
- Added option to setup `ImagePipeline` with data cache (on disk)
- A couple of new methods to:
  - check if an image is in cache (all layers)
  - get an `UIImage` directly 
  - remove specific image from caches
  - clean all cache layers
- More options added to the sample project
- Typo in readme