### PR TITLE
Expose LoadImage with URLRequest in the proxy

### DIFF
--- a/NukeProxy/NukeProxy.swift
+++ b/NukeProxy/NukeProxy.swift
@@ -62,6 +62,22 @@ public class ImagePipeline : NSObject {
         )
     }
     
+    @objc
+    public func loadImage(urlRequest: URLRequest, onCompleted: @escaping (UIImage?, String) -> Void) {
+        _ = Nuke.ImagePipeline.shared.loadImage(
+            with: urlRequest,
+            progress: nil,
+            completion: { result in
+                switch result {
+                case let .success(response):
+                    onCompleted(response.image, "success")
+                case let .failure(error):
+                    onCompleted(nil, error.localizedDescription)
+                }
+            }
+        )
+    }
+    
     
     @objc
     public func loadImage(url: URL?, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
@@ -70,11 +86,27 @@ public class ImagePipeline : NSObject {
     }
     
     @objc
+    public func loadImage(urlRequest: URLRequest, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
+        let options = ImageLoadingOptions(placeholder: placeholder, failureImage: errorImage)
+        Nuke.loadImage(with: urlRequest, options: options, into: into)
+    }
+    
+    @objc
     public func loadImage(url: URL?, imageIdKey: String, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
         let options = ImageLoadingOptions(placeholder: placeholder, failureImage: errorImage)
         
         Nuke.loadImage(with: ImageRequest(
             url: url,
+            userInfo: [.imageIdKey: imageIdKey]
+        ), options: options, into: into)
+    }
+    
+    @objc
+    public func loadImage(urlRequest: URLRequest, imageIdKey: String, placeholder: UIImage?, errorImage: UIImage?, into: UIImageView) {
+        let options = ImageLoadingOptions(placeholder: placeholder, failureImage: errorImage)
+        
+        Nuke.loadImage(with: ImageRequest(
+            urlRequest: urlRequest,
             userInfo: [.imageIdKey: imageIdKey]
         ), options: options, into: into)
     }

--- a/src/ImageCaching.Nuke/ApiDefinition.cs
+++ b/src/ImageCaching.Nuke/ApiDefinition.cs
@@ -69,13 +69,25 @@ namespace ImageCaching.Nuke
         [Export ("loadImageWithUrl:onCompleted:")]
 		void LoadImageWithUrl ([NullAllowed] NSUrl url, Action<UIImage, NSString> onCompleted);
 
+		// -(void)loadImageWithUrlRequest:(NSURLRequest * _Nonnull)urlRequest onCompleted:(void (^ _Nonnull)(UIImage * _Nullable, NSString * _Nonnull))onCompleted;
+		[Export ("loadImageWithUrlRequest:onCompleted:")]
+		void LoadImageWithUrlRequest (NSUrlRequest urlRequest, Action<UIImage, NSString> onCompleted);
+
         // -(void)loadImageWithUrl:(NSURL * _Nullable)url placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
         [Export ("loadImageWithUrl:placeholder:errorImage:into:")]
 		void LoadImageWithUrl ([NullAllowed] NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
 
+		// -(void)loadImageWithUrlRequest:(NSURLRequest * _Nonnull)urlRequest placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
+		[Export ("loadImageWithUrlRequest:placeholder:errorImage:into:")]
+		void LoadImageWithUrlRequest (NSUrlRequest urlRequest, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
+
         // -(void)loadImageWithUrl:(NSURL * _Nullable)url imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
         [Export ("loadImageWithUrl:imageIdKey:placeholder:errorImage:into:")]
 		void LoadImageWithUrl ([NullAllowed] NSUrl url, string imageIdKey, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
+
+		// -(void)loadImageWithUrlRequest:(NSURLRequest * _Nonnull)urlRequest imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
+		[Export ("loadImageWithUrlRequest:imageIdKey:placeholder:errorImage:into:")]
+		void LoadImageWithUrlRequest (NSUrlRequest urlRequest, string imageIdKey, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
 
         // -(void)loadDataWithUrl:(NSURL * _Nullable)url onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSURLResponse * _Nullable))onCompleted;
         [Export ("loadDataWithUrl:onCompleted:")]


### PR DESCRIPTION
Adding proxy methods for the underlying loadImage with URLRequest, so that callers can specify their own url request data, such as passing authentication headers to url requests.

This is a non-breaking change, and could be leveraged by the Nuke Maui repo if wanted to add ability to set the url request directly or allow passing headers.