### PR TITLE
Add methods to cancel image loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: macOS-15
     env:
-      XCODE_VERSION: 16
-      dotnetVersion: 9.0.100
+      XCODE_VERSION: 16.2
+      dotnetVersion: 9.0.200
 
     steps:
       - name: Checkout

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p artifacts
+
 echo "Update carthage deps"
 sh carthage.sh update --use-xcframeworks --platform iOS --log-path artifacts/carthage.log
 

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ echo 'exit 0' > Carthage/Checkouts/Nuke/Scripts/validate.sh
 
 sh carthage.sh build --use-xcframeworks --platform iOS --log-path artifacts/carthage.log
 
+rm -r Output/NukeProxy.xcframework
+
 echo "xcode build"
 xcodebuild archive -sdk iphoneos -project NukeProxy.xcodeproj -scheme NukeProxy -configuration Release -archivePath Output/Output-iphoneos SKIP_INSTALL=NO
 xcodebuild archive -sdk iphonesimulator -project NukeProxy.xcodeproj -scheme NukeProxy -configuration Release -archivePath Output/Output-iphonesimulator SKIP_INSTALL=NO

--- a/src/ImageCaching.Nuke/ApiDefinition.cs
+++ b/src/ImageCaching.Nuke/ApiDefinition.cs
@@ -92,6 +92,10 @@ namespace ImageCaching.Nuke
 		// -(void)loadDataWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nullable)imageIdKey reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSUrlResponse * _Nullable))onCompleted;
 		[Export ("loadDataWithUrl:imageIdKey:reloadIgnoringCachedData:onCompleted:")]
 		void LoadDataWithUrl (NSUrl url, [NullAllowed] string imageIdKey, bool reloadIgnoringCachedData, Action<NSData, NSUrlResponse> onCompleted);
+
+		// -(void)cancelTask:(NSString * _Nonnull)url;
+		[Export ("cancelTask:")]
+		void CancelTask (string url);
 	}
 
 	// @interface Prefetcher : NSObject

--- a/src/ImageCaching.Nuke/ApiDefinition.cs
+++ b/src/ImageCaching.Nuke/ApiDefinition.cs
@@ -65,37 +65,41 @@ namespace ImageCaching.Nuke
 		[Export ("removeAllCaches")]
 		void RemoveAllCaches ();
 
-		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url onCompleted:(void (^ _Nonnull)(UIImage * _Nullable, NSString * _Nonnull))onCompleted;
+		// -(Int64)loadImageWithUrl:(NSURL * _Nonnull)url onCompleted:(void (^ _Nonnull)(UIImage * _Nullable, NSString * _Nonnull))onCompleted;
 		[Export ("loadImageWithUrl:onCompleted:")]
-		void LoadImageWithUrl (NSUrl url, Action<UIImage, NSString> onCompleted);
+		long LoadImageWithUrl (NSUrl url, Action<UIImage, NSString> onCompleted);
 
-		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
+		// -(Int64)loadImageWithUrl:(NSURL * _Nonnull)url placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
 		[Export ("loadImageWithUrl:placeholder:errorImage:into:")]
-		void LoadImageWithUrl (NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
+		long LoadImageWithUrl (NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
 
-		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData;
+		// -(Int64)loadImageWithUrl:(NSURL * _Nonnull)url placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData;
 		[Export ("loadImageWithUrl:placeholder:errorImage:into:reloadIgnoringCachedData:")]
-		void LoadImageWithUrl (NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into, bool reloadIgnoringCachedData);
+		long LoadImageWithUrl (NSUrl url, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into, bool reloadIgnoringCachedData);
 
-		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
+		// -(Int64)loadImageWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into;
 		[Export ("loadImageWithUrl:imageIdKey:placeholder:errorImage:into:")]
-		void LoadImageWithUrl (NSUrl url, string imageIdKey, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
+		long LoadImageWithUrl (NSUrl url, string imageIdKey, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into);
 
-		// -(void)loadImageWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData;
+		// -(Int64)loadImageWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nonnull)imageIdKey placeholder:(UIImage * _Nullable)placeholder errorImage:(UIImage * _Nullable)errorImage into:(UIImageView * _Nonnull)into reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData;
 		[Export ("loadImageWithUrl:imageIdKey:placeholder:errorImage:into:reloadIgnoringCachedData:")]
-		void LoadImageWithUrl (NSUrl url, string imageIdKey, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into, bool reloadIgnoringCachedData);
+		long LoadImageWithUrl (NSUrl url, string imageIdKey, [NullAllowed] UIImage placeholder, [NullAllowed] UIImage errorImage, UIImageView into, bool reloadIgnoringCachedData);
 
-		// -(void)loadDataWithUrl:(NSURL * _Nonnull)url onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSUrlResponse * _Nullable))onCompleted;
+		// -(Int64)loadDataWithUrl:(NSURL * _Nonnull)url onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSUrlResponse * _Nullable))onCompleted;
 		[Export ("loadDataWithUrl:onCompleted:")]
-		void LoadDataWithUrl (NSUrl url, Action<NSData, NSUrlResponse> onCompleted);
+		long LoadDataWithUrl (NSUrl url, Action<NSData, NSUrlResponse> onCompleted);
 
-		// -(void)loadDataWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nullable)imageIdKey reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSUrlResponse * _Nullable))onCompleted;
+		// -(Int64)loadDataWithUrl:(NSURL * _Nonnull)url imageIdKey:(NSString * _Nullable)imageIdKey reloadIgnoringCachedData:(BOOL)reloadIgnoringCachedData onCompleted:(void (^ _Nonnull)(NSData * _Nullable, NSUrlResponse * _Nullable))onCompleted;
 		[Export ("loadDataWithUrl:imageIdKey:reloadIgnoringCachedData:onCompleted:")]
-		void LoadDataWithUrl (NSUrl url, [NullAllowed] string imageIdKey, bool reloadIgnoringCachedData, Action<NSData, NSUrlResponse> onCompleted);
+		long LoadDataWithUrl (NSUrl url, [NullAllowed] string imageIdKey, bool reloadIgnoringCachedData, Action<NSData, NSUrlResponse> onCompleted);
 
-		// -(void)cancelTask:(NSString * _Nonnull)url;
+		// -(Int64)cancelTasksForUrl:(NSString * _Nonnull)url;
+		[Export ("cancelTasksForUrl:")]
+		void CancelTasksForUrl (string url);
+
+		// -(void)cancelTask:(Int64 * _Nonnull)taskId;
 		[Export ("cancelTask:")]
-		void CancelTask (string url);
+		void CancelTask (long taskId);
 	}
 
 	// @interface Prefetcher : NSObject

--- a/src/Sample/ImageTableViewController.cs
+++ b/src/Sample/ImageTableViewController.cs
@@ -1,0 +1,148 @@
+using System;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+using ImageCaching.Nuke;
+using ObjCRuntime;
+
+namespace Sample;
+
+public class ImageTableViewController : UIViewController
+{
+    public ImageTableViewController()
+    {
+
+    }
+
+    public override void LoadView()
+    {
+        base.LoadView();
+
+        var layout = new UICollectionViewFlowLayout
+        {
+            ItemSize = new CGSize(UIScreen.MainScreen.Bounds.Width, 100),
+            MinimumInteritemSpacing = 8,
+            ScrollDirection = UICollectionViewScrollDirection.Vertical
+        };
+        var collectionView = new UICollectionView(CGRect.Empty, layout)
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            DataSource = new ImageDataSource()
+        };
+
+        collectionView.RegisterClassForCell(typeof(ImageCell), nameof(ImageCell));
+
+        Add(collectionView);
+
+        collectionView.TopAnchor.ConstraintEqualTo(View.TopAnchor).Active = true;
+        collectionView.BottomAnchor.ConstraintEqualTo(View.BottomAnchor).Active = true;
+        collectionView.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor).Active = true;
+        collectionView.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor).Active = true;
+    }
+}
+
+public class ImageDataSource : UICollectionViewDataSource
+{
+    private readonly string[] _items;
+
+    public ImageDataSource()
+    {
+        _items =
+        [
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item2",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item3",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item3",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item4",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item5",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item6",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item3",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item4",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item5",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item6",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item2",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item2",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item1",
+            "https://www.dummyimage.com/600x400/e30ce3/8bd61a.png&text=Item7",
+        ];
+    }
+
+    public override IntPtr GetItemsCount(UICollectionView collectionView, IntPtr section)
+    {
+        return _items.Length;
+    }
+
+    public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
+    {
+        var cell = collectionView.DequeueReusableCell(nameof(ImageCell), indexPath);
+        if (cell is ImageCell imageCell)
+        {
+            imageCell.LoadImage(_items[indexPath.Row]);
+        }
+
+        return (UICollectionViewCell)cell;
+    }
+}
+
+public sealed class ImageCell : UICollectionViewCell
+{
+    private readonly UIImageView _imageView;
+    private long? _taskId;
+
+    public ImageCell(NativeHandle handle) : base(handle)
+    {
+        _imageView = new UIImageView
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            ContentMode = UIViewContentMode.ScaleToFill
+        };
+
+        ContentView.Add(_imageView);
+        ContentView.BackgroundColor = UIColor.Gray;
+
+        _imageView.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor).Active = true;
+        _imageView.BottomAnchor.ConstraintEqualTo(ContentView.BottomAnchor).Active = true;
+        _imageView.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor).Active = true;
+        _imageView.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor).Active = true;
+    }
+
+    public void LoadImage(string url)
+    {
+        _taskId = ImagePipeline.Shared.LoadImageWithUrl(
+            new NSUrl(url),
+            UIImage.FromBundle("Placeholder"),
+            null,
+            _imageView);
+    }
+
+    public override void PrepareForReuse()
+    {
+        if (_taskId.HasValue)
+            ImagePipeline.Shared.CancelTask(_taskId.Value);
+
+        base.PrepareForReuse();
+    }
+}

--- a/src/Sample/Main.storyboard
+++ b/src/Sample/Main.storyboard
@@ -1,27 +1,48 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Kld-UM-pVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
+                    <navigationItem key="navigationItem" id="cXX-f6-fRw"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="0.0" y="0.0"/>
+            <point key="canvasLocation" x="925.95419847328242" y="0.0"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="huq-1E-aiY">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Kld-UM-pVM" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="IcS-XP-4d2">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="yug-Eu-Amp"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qOT-Oj-B4A" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-0.76335877862595414" y="0.0"/>
         </scene>
     </scenes>
 </document>

--- a/src/Sample/ViewController.cs
+++ b/src/Sample/ViewController.cs
@@ -20,7 +20,8 @@ namespace Sample
         private SKCanvasView _skiaCanvasView;
         private UIStackView _bottomStackView;
         private UILabel _cacheStatusLabel;
-        
+        private UIButton _imageListButton;
+
         public ViewController(IntPtr handle) : base(handle)
         {
         }
@@ -106,6 +107,12 @@ namespace Sample
                 _skiaCanvasView.LayoutSubviews();
                  _imageView.Image = null;
             };
+
+            _imageListButton = AddButton("Image List");
+            _imageListButton.TouchUpInside += (sender, args) =>
+            {
+                NavigationController.PushViewController(new ImageTableViewController(), true);
+            };
             
             _prefetchButton = AddButton("Prefetch above images");
             _prefetchButton.TouchUpInside += (sender, args) =>
@@ -122,6 +129,7 @@ namespace Sample
             _cacheStatusLabel = new UILabel(){ Lines = 0, TranslatesAutoresizingMaskIntoConstraints = false};
             
             _bottomStackView.AddArrangedSubview(_clearButton);
+            _bottomStackView.AddArrangedSubview(_imageListButton);
             _bottomStackView.AddArrangedSubview(_prefetchButton);
             _bottomStackView.AddArrangedSubview(_dumpCacheStateButton);
             


### PR DESCRIPTION
To allow a developer to cancel loading images. I.e. when a cell is being reused, I've introduced a couple of methods. These allow you to cancel all running tasks based on URL, or by taskId, which is now returned by all load image methods.

To try this out a new list sample was added which demonstrates the cancellation